### PR TITLE
Fix the issue of serial port ttyUSB0 in Grub boot. 

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -38,6 +38,12 @@ TARGET_INITRD_DIR := $(PRODUCT_OUT)/initrd
 LOCAL_INITRD_DIR := $(LOCAL_PATH)/initrd
 BOOT_DIR := $(LOCAL_PATH)/boot
 INITRD := $(PRODUCT_OUT)/initrd.img
+
+SERIAL = ttyUSB0
+ifeq ($(findstring $(SERIAL),$(SERIAL_PARAMETER)),$(SERIAL))
+SERIAL_PARAMETER := console=ttyS0,115200n8
+endif
+
 $(INITRD): $(LOCAL_PATH)/initrd/init $(wildcard $(LOCAL_PATH)/initrd/*/*) | $(MKBOOTFS)
 	rm -rf $(TARGET_INITRD_DIR)
 	$(ACP) -dprf $(LOCAL_INITRD_DIR) $(TARGET_INITRD_DIR)

--- a/boot/boot/grub/grub.cfg
+++ b/boot/boot/grub/grub.cfg
@@ -6,8 +6,18 @@ menuentry 'PROJECTCELADON Install with kernelflinger (BUILDDATE)' --class projec
 	initrd /initrd.img
 }
 
+menuentry 'PROJECTCELADON Install with kernelflinger (BUILDDATE) (Serial debug)' --class projectceladon {
+	linux /kernel KERNEL_CMDLINE LIVE=1 INSTALL=1 KERNELFLINGER=1 ignore_loglevel printk.devkmsg=on SERIAL_PORT
+	initrd /initrd.img
+}
+
 menuentry 'PROJECTCELADON Install (BUILDDATE)' --class projectceladon {
 	linux /kernel KERNEL_CMDLINE LIVE=1 INSTALL=1 CONSOLE
+	initrd /initrd.img
+}
+
+menuentry 'PROJECTCELADON Install (BUILDDATE) (Serial debug)' --class projectceladon {
+	linux /kernel KERNEL_CMDLINE LIVE=1 INSTALL=1 debug ignore_loglevel printk.devkmsg=on SERIAL_PORT
 	initrd /initrd.img
 }
 
@@ -16,7 +26,17 @@ menuentry 'PROJECTCELADON Live Boot (BUILDDATE)' --class projectceladon {
 	initrd /initrd.img
 }
 
+menuentry 'PROJECTCELADON Live Boot (BUILDDATE) (Serial debug)' --class projectceladon {
+	linux /kernel KERNEL_CMDLINE LIVE=1 androidboot.selinux=permissive debug ignore_loglevel printk.devkmsg=on SERIAL_PORT
+	initrd /initrd.img
+}
+
 menuentry 'PROJECTCELADON Debug Shell (BUILDDATE)' --class projectceladon {
 	linux /kernel KERNEL_CMDLINE LIVE=1 DEBUG=1 androidboot.selinux=permissive debug CONSOLE
+	initrd /initrd.img
+}
+
+menuentry 'PROJECTCELADON Debug Shell (BUILDDATE) (Serial debug)' --class projectceladon {
+	linux /kernel KERNEL_CMDLINE LIVE=1 DEBUG=1 androidboot.selinux=permissive debug ignore_loglevel printk.devkmsg=on SERIAL_PORT
 	initrd /initrd.img
 }

--- a/boot/boot/grub/grub_kfonly.cfg
+++ b/boot/boot/grub/grub_kfonly.cfg
@@ -6,7 +6,18 @@ menuentry 'PROJECTCELADON Install with kernelflinger (BUILDDATE)' --class projec
 	initrd /initrd.img
 }
 
+menuentry 'PROJECTCELADON Install with kernelflinger (BUILDDATE) (Serial debug)' --class projectceladon {
+	linux /kernel KERNEL_CMDLINE LIVE=1 INSTALL=1 KERNELFLINGER=1 ignore_loglevel printk.devkmsg=on SERIAL_PORT
+	initrd /initrd.img
+}
+
 menuentry 'PROJECTCELADON Debug Shell (BUILDDATE)' --class projectceladon {
 	linux /kernel KERNEL_CMDLINE LIVE=1 DEBUG=1 androidboot.selinux=permissive debug CONSOLE
 	initrd /initrd.img
 }
+
+menuentry 'PROJECTCELADON Debug Shell (BUILDDATE) (Serial debug)' --class projectceladon {
+	linux /kernel KERNEL_CMDLINE LIVE=1 DEBUG=1 androidboot.selinux=permissive debug ignore_loglevel printk.devkmsg=on SERIAL_PORT
+	initrd /initrd.img
+}
+


### PR DESCRIPTION
…boot.

If use the ttyUSB0 to enter debug shell in grub boot, a kernel panic
will occur.Because the serial port ttyUSB0 was loaded too late, thus
affected the earlyprintk and console. so,use the serial port ttyS0 or
tty0 to debug shell in grub.thus avoided the kernel crash or reboot 
before runnig the init script.

Tracked-On: OAM-83266
Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>