### PR TITLE
Generate grub image conditionally

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -26,6 +26,7 @@ UNSPARSER := $(HOST_OUT_EXECUTABLES)/simg2img
 SQUASHER := $(HOST_OUT_EXECUTABLES)/mksquashfs
 include $(BUILD_HOST_EXECUTABLE)
 
+ifeq ($(ENABLE_GRUB_INSTALLER),true)
 GRUB_DEFAULT := 0
 ifeq ($(CI_BUILD),true)
 GRUB_TIMEOUT := 1
@@ -111,6 +112,13 @@ $(PROJECT_CELADON-EFI): $(GRUB_FILES) | $(install_mbr)
 	cat /dev/null > $@; $(install_mbr) -l $(DISK_LAYOUT) -i $@ oand=$@.fat
 	rm -f $@.fat
 
+endif # ENABLE_GRUB_INSTALLER
+
 .PHONY: project_celadon-efi
+ifneq ($(TARGET_BUILD_VARIANT), user)
 project_celadon-efi: $(PROJECT_CELADON-EFI)
+else
+project_celadon-efi:
+	echo "Do not generate grub installer in user mode"
+endif
 


### PR DESCRIPTION
Generate grub image only when option grub_installer is enabled
in mixins or ENABLE_GRUB_INSTALLER is set to true in make command line.
Grub image only be built in eng or userdebug build.

Tracked-On: OAM-85443
Signed-off-by: Meng Xianglin <xianglinx.meng@intel.com>